### PR TITLE
Fix image proxy output buffering corruption and CSS typos

### DIFF
--- a/gallery-for-immich.php
+++ b/gallery-for-immich.php
@@ -221,6 +221,14 @@ class Gallery_For_Immich {
             exit('Asset not found');
         }
 
+        // Kill ALL output buffering to prevent stray bytes corrupting binary image output.
+        // Servers with output_buffering enabled in php.ini (common on shared hosts) accumulate
+        // buffered output during WordPress bootstrap, which prepends garbage bytes to the image
+        // data and breaks the JPEG header. This mirrors the pattern already used for video streaming.
+        while (ob_get_level() > 0) {
+            ob_end_clean();
+        }
+
         // Security headers
         header('Content-Type: image/jpeg');
         header('X-Content-Type-Options: nosniff');
@@ -672,7 +680,7 @@ class Gallery_For_Immich {
                 max-width: 95vw !important;
                 max-height: 95vh !important;
                 width: auto !important;
-                heught: auto !important;
+                height: auto !important;
                 object-fit: contain !important;
                 display: block !important;
                 margin: 0 auto !important;
@@ -688,7 +696,7 @@ class Gallery_For_Immich {
             .glightbox-container .gslide-inline,
             .glightbox-container .ginlined-content {
                 background: transparent !important;
-                padding: 0 !important;f
+                padding: 0 !important;
                 align-items: center;
                 justify-content: center;
             }


### PR DESCRIPTION
## Summary

Three bugs fixed, all discovered while debugging the plugin on an OVHcloud shared hosting server.

---

### Bug 1 (critical): Image proxy corrupted on servers with `output_buffering` enabled

**Symptom:** Images load as thumbnails in the gallery grid but fail to display in the lightbox. Fetching a preview URL directly returns a file with stray bytes prepended to the JPEG data, making it unreadable by browsers and image tools.

**Root cause:** PHP servers with `output_buffering = On` in `php.ini` (common on shared hosts) accumulate buffered output during WordPress bootstrap before the proxy handler runs. These bytes (typically `\n\n\n\n`) are prepended to the binary image response, breaking the JPEG header.

**Why it works on some servers:** Servers with `output_buffering = Off` are unaffected, which is why the bug isn't universally reproducible.

**Fix:** Flush all output buffers before sending image headers and data. This mirrors the pattern already correctly used in the video streaming path (lines 124–125).

```php
// Before sending image headers:
while (ob_get_level() > 0) {
    ob_end_clean();
}
```

---

### Bug 2 (minor): CSS typo `heught` instead of `height`

In the inline CSS for `.gslide img`, `heught: auto !important` is a no-op — the browser ignores the unknown property, so lightbox images don't respect the `height: auto` constraint.

---

### Bug 3 (minor): Stray `f` character after CSS semicolon

In the `.gslide-inline` / `.ginlined-content` rule, `padding: 0 !important;f` causes the browser to discard the subsequent `align-items` and `justify-content` declarations, breaking centering of inline content.